### PR TITLE
[small] Feature/002

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@mdi/font": "^7.4.47",
         "material-design-icons-iconfont": "^6.7.0",
         "vue": "^3.5.10",
+        "vue-cal": "^4.10.0",
         "vue-router": "^4.4.5",
         "vuetify": "^3.7.0-beta.1"
       },
@@ -1026,6 +1027,17 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-cal": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/vue-cal/-/vue-cal-4.10.0.tgz",
+      "integrity": "sha512-gKOW+UAsUhzJHog/c3dfWN/CwxohpvO4ipBHzDWVngm+R0XZxly8NsGvczYmkfb3pFpuTP29ilAb0ix0sSsULg==",
+      "funding": {
+        "url": "https://github.com/sponsors/antoniandre"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
       }
     },
     "node_modules/vue-router": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@mdi/font": "^7.4.47",
     "material-design-icons-iconfont": "^6.7.0",
     "vue": "^3.5.10",
+    "vue-cal": "^4.10.0",
     "vue-router": "^4.4.5",
     "vuetify": "^3.7.0-beta.1"
   },

--- a/src/components/ScheduleView.vue
+++ b/src/components/ScheduleView.vue
@@ -1,57 +1,40 @@
 <template>
-    <div class="schedule-view">
-      <h2>スケジュール一覧</h2>
-      <table class="schedule-table">
-        <thead>
-          <tr>
-            <th>日付</th>
-            <th>イベント名</th>
-            <th>詳細</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="(event, index) in events" :key="index">
-            <td>{{ event.date }}</td>
-            <td>{{ event.name }}</td>
-            <td>{{ event.details }}</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </template>
-  
-  <script>
-  export default {
-    name: 'ScheduleView',
-    data() {
-      return {
-        events: [
-          { date: '2024-10-01', name: 'ミーティング', details: 'プロジェクトの進捗確認' },
-          { date: '2024-10-05', name: 'ワークショップ', details: '新技術の勉強会' },
-          // 他のイベントも追加できます
-        ],
-      };
-    },
-  };
-  </script>
-  
-  <style scoped>
-  .schedule-view {
-    padding: 20px;
-  }
-  
-  .schedule-table {
-    width: 100%;
-    border-collapse: collapse;
-  }
-  
-  .schedule-table th, .schedule-table td {
-    border: 1px solid #ccc;
-    padding: 8px;
-    text-align: left;
-  }
-  
-  .schedule-table th {
-    background-color: #f2f2f2;
-  }
-  </style>
+  <v-app>
+    <v-main>
+      <vue-cal :events="events"></vue-cal>
+    </v-main>
+  </v-app>
+</template>
+
+<script>
+import VueCal from 'vue-cal';
+import 'vue-cal/dist/vuecal.css'; // CSSをインポート
+
+export default {
+  components: {
+    VueCal,
+  },
+  data() {
+    return {
+      events: [
+        {
+          start: '2024-10-19',
+          end: '2024-10-19',
+          title: 'Event 1',
+        },
+        {
+          start: '2024-10-21',
+          end: '2024-10-22',
+          title: 'Event 2',
+        },
+      ],
+    };
+  },
+};
+</script>
+
+<style scoped>
+.v-calendar {
+  height: 600px;
+}
+</style>


### PR DESCRIPTION
✅v-carenderをPJで使用できるようにする
✅UploadViewコンポーネントにv-carenderの実装
✅同Componetsのdata()でコンポーネントデータにサンプルデータを入れる

```
start: '2024-10-19',
end: '2024-10-19',
title: 'Event 1',
```
***NEXT***
**→v-calenerのdata()コンポーネントについてAPI側の考慮の必要性**

**finaly**
npm run dev でローカルアクセスして、
スケジュール表示画面にv-carenderの表示が実装されている事
→表示を確認
![スクリーンショット 2024-10-21 230224](https://github.com/user-attachments/assets/d72918b0-c41c-451e-b989-ff25e95aa60a)
