### PR TITLE
イベントの開始時間・終了時間の選択UI改善と時間フォーマットの変更UI側修正

### DIFF
--- a/src/components/ScheduleView.vue
+++ b/src/components/ScheduleView.vue
@@ -19,7 +19,9 @@
       ></vue-cal>
       <v-dialog v-model="dialog" max-width="400" class="custom-dialog">
         <v-card>
-          <v-card-title class="headline">{{ isEdit ? 'イベントを更新' : '新規イベントを登録' }}</v-card-title>
+          <v-card-title class="headline">{{
+            isEdit ? "イベントを更新" : "新規イベントを登録"
+          }}</v-card-title>
           <v-card-text>
             <v-text-field
               v-model="selectedEventTitle"
@@ -32,40 +34,44 @@
               placeholder="詳細を入力"
               rows="3"
             ></v-textarea>
-            <v-menu
-            v-model="datePicker"
-            :close-on-content-click="false"
-            transition="scale-transition"
-            offset-y
-            min-width="290px"
-          >
-            <template v-slot:activator="{ on }">
-              <v-text-field
+            <br />
+            <v-manu>
+              <VueDatePicker
+                placeholder="日付"
                 v-model="selectedDate"
-                label="日付"
-                prepend-icon="mdi-calendar"
-                readonly
-                v-bind="on"
-              ></v-text-field>
-              <VueDatePicker v-model="selectedDate"
-              format="yyyy/MM/dd"
-              model-type="yyyy-MM-dd"/>
-            </template>
-          </v-menu>
-            <v-text-field
-              v-model="selectedEventStartTime"
-              label="開始時間"
-              placeholder="HH:mm形式で入力"
-            ></v-text-field>
-            <v-text-field
-              v-model="selectedEventEndTime"
-              label="終了時間"
-              placeholder="HH:mm形式で入力"
-            ></v-text-field>
+                format="yyyy/MM/dd"
+                model-type="yyyy-MM-dd"
+                :enable-time-picker="false"
+              />
+            </v-manu>
+            <br />
+            <v-manu>
+              <VueDatePicker
+                time-picker
+                disable-time-range-validation
+                v-model="selectedEventStartTime"
+                placeholder="開始時刻"
+                type="time"
+                format="HH:mm"
+              />
+            </v-manu>
+            <br />
+            <v-manu>
+              <VueDatePicker
+                time-picker
+                disable-time-range-validation
+                v-model="selectedEventEndTime"
+                placeholder="終了時刻"
+                type="time"
+                format="HH:mm"
+              />
+            </v-manu>
           </v-card-text>
           <v-card-actions>
             <v-spacer></v-spacer>
-            <v-btn color="primary" text @click="saveEvent">{{ isEdit ? '更新' : '保存' }}</v-btn>
+            <v-btn color="primary" text @click="saveEvent">{{
+              isEdit ? "更新" : "保存"
+            }}</v-btn>
             <v-btn color="primary" text @click="dialog = false">閉じる</v-btn>
           </v-card-actions>
         </v-card>
@@ -75,12 +81,12 @@
 </template>
 
 <script>
-import VueCal from 'vue-cal';
-import apiFacade from '../services/apiFacade';
-import 'vue-cal/dist/vuecal.css';
-import 'vuetify/dist/vuetify.min.css';
-import VueDatePicker from '@vuepic/vue-datepicker';
-import '@vuepic/vue-datepicker/dist/main.css';
+import VueCal from "vue-cal";
+import apiFacade from "../services/apiFacade";
+import "vue-cal/dist/vuecal.css";
+import "vuetify/dist/vuetify.min.css";
+import VueDatePicker from "@vuepic/vue-datepicker";
+import "@vuepic/vue-datepicker/dist/main.css";
 
 export default {
   components: {
@@ -89,19 +95,19 @@ export default {
   computed: {
     userId() {
       return this.$store.state.userId; // VuexストアからuserIdを取得
-    }
+    },
   },
   data() {
     return {
       events: [],
       dialog: false,
       isEdit: false,
-      selectedEventTitle: '',
-      selectedEventContents: '',
-      selectedEventStartTime: '',
-      selectedEventEndTime: '',
-      selectedDateTime: null,
-      dataPicker: '',
+      selectedEventTitle: "",
+      selectedEventContents: "",
+      selectedEventStartTime: "",
+      selectedEventEndTime: "",
+      selectedDate: "",
+      dataPicker: "",
     };
   },
   created() {
@@ -113,7 +119,7 @@ export default {
         const activities = await apiFacade.getActivities(this.userId);
         this.events = activities;
       } catch (error) {
-        console.error('Error fetching activities:', error);
+        console.error("Error fetching activities:", error);
       }
     },
     handleDateClick(date) {
@@ -121,42 +127,46 @@ export default {
       this.selectedDateTime = clickedDateTime;
 
       // clickedDateTimeを基にイベントを検索
-      const clickedEvent = this.events.find(event => {
-      const eventStart = new Date(event.start);
-      const eventEnd = new Date(event.end);
+      const clickedEvent = this.events.find((event) => {
+        const eventStart = new Date(event.start);
+        const eventEnd = new Date(event.end);
         return this.events; // イベントがあるかどうか
       });
 
       if (clickedEvent) {
-      // クリックしたイベントの詳細を設定
+        // クリックしたイベントの詳細を設定
         this.selectedEventTitle = clickedEvent.title;
         this.selectedEventContents = clickedEvent.contents; // 詳細を設定
         this.isEdit = true;
-        this.selectedEventStartTime = new Date(clickedEvent.start).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-        this.selectedEventEndTime = new Date(clickedEvent.end).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+        this.selectedEventStartTime = new Date(
+          clickedEvent.start
+        ).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+        this.selectedEventEndTime = new Date(
+          clickedEvent.end
+        ).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
       } else {
-      // 新規イベントのための初期化
-        this.selectedEventTitle = '';
-        this.selectedEventContents = '';
-        this.selectedEventStartTime = ''; // 空に初期化
-        this.selectedEventEndTime = ''; // 空に初期化
+        // 新規イベントのための初期化
+        this.selectedEventTitle = "";
+        this.selectedEventContents = "";
+        this.selectedEventStartTime = ""; // 空に初期化
+        this.selectedEventEndTime = ""; // 空に初期化
         this.isEdit = false;
       }
       // ダイアログを表示
-     this.dialog = true;
+      this.dialog = true;
     },
     newCreate(date) {
-      this.selectedDateTime = new Date(date);
-      this.selectedEventTitle = '';
-      this.selectedEventContents = '';
-      this.selectedEventStartTime = '';
-      this.selectedEventEndTime = '';
+      this.selectedDate = "";
+      this.selectedEventTitle = "";
+      this.selectedEventContents = "";
+      this.selectedEventStartTime = "";
+      this.selectedEventEndTime = "";
       this.isEdit = false;
       this.dialog = true;
     },
     saveEvent() {
       if (this.isEdit) {
-        const eventIndex = this.events.findIndex(event => {
+        const eventIndex = this.events.findIndex((event) => {
           const eventStart = new Date(event.start);
           return eventStart.getTime() === this.selectedDateTime.getTime();
         });
@@ -164,10 +174,16 @@ export default {
         if (eventIndex !== -1) {
           this.events[eventIndex].title = this.selectedEventTitle;
           this.events[eventIndex].details = this.selectedEventContents;
-          this.events[eventIndex].start = new Date(`${this.selectedDateTime.toDateString()} ${this.selectedEventStartTime}`).toISOString();
-          this.events[eventIndex].end = new Date(`${this.selectedDateTime.toDateString()} ${this.selectedEventEndTime}`).toISOString();
+          this.events[eventIndex].start = new Date(
+            `${this.selectedDateTime.toDateString()} ${this.selectedEventStartTime}`
+          ).toISOString();
+          this.events[eventIndex].end = new Date(
+            `${this.selectedDateTime.toDateString()} ${this.selectedEventEndTime}`
+          ).toISOString();
         }
       } else {
+        this.formatTime(this.selectedEventStartTime, "start");
+        this.formatTime(this.selectedEventEndTime, "end");
         const eventData = {
           userId: this.userId,
           date: this.selectedDate,
@@ -176,21 +192,38 @@ export default {
           title: this.selectedEventTitle,
           contents: this.selectedEventContents,
         };
-        apiFacade.createActivity(eventData) 
+        apiFacade
+          .createActivity(eventData)
           .then(() => {
-              return this.fetchActivities(); // 成功したら再取得して一覧を更新
+            return this.fetchActivities(); // 成功したら再取得して一覧を更新
           })
           .then(() => {
-              this.dialog = false; // ダイアログを閉じる
+            this.dialog = false; // ダイアログを閉じる
           })
-          .catch(error => {
-              console.error('Error adding event:', error); // エラーハンドリング
+          .catch((error) => {
+            console.error("Error adding event:", error); // エラーハンドリング
           });
       }
       this.dialog = false;
     },
-  }
-}
+    // 時間をHH:mm形式に変換して格納
+    formatTime(timeObj, type) {
+      if (timeObj && timeObj.hours !== undefined) {
+        // HH:mm形式にフォーマット
+        const hours = String(timeObj.hours).padStart(2, "0");
+        const minutes = String(timeObj.minutes).padStart(2, "0");
+        const formattedTime = `${hours}:${minutes}`;
+
+        // API用に変換された時間を格納
+        if (type === "start") {
+          this.selectedEventStartTime = formattedTime;
+        } else if (type === "end") {
+          this.selectedEventEndTime = formattedTime;
+        }
+      }
+    },
+  },
+};
 </script>
 
 <style scoped>


### PR DESCRIPTION
#### 概要:
イベントの開始時間と終了時間を選択するUIを改善し、ユーザーが時間を直感的に選べるようにしました。選択された時間は、APIに送信する際に`HH:mm`形式に変換されるように実装しました。

#### 変更内容:
- `v-text-field`を`VueDatePicker`の`type="time"`に置き換え、時間選択を実現。
- 選択された時間を`HH:mm`形式でフォーマットし、保存時にAPIに送信。
- 保存ボタンを押した際、時間を適切に変換してAPIに送信する処理を追加。

#### メリット:
- ユーザーが時間を簡単に選べるようになり、UXが向上。
- 時間データがAPIと整合性の取れた形式で送信され、処理がスムーズに。

---
***English***

### PR Title: Improvement of Event Start/End Time Selection UI and Time Format Change

#### Overview:
Improved the UI for selecting event start and end times, allowing users to intuitively choose the time. The selected time is formatted into `HH:mm` format before being sent to the API.

#### Changes:
- Replaced `v-text-field` with `VueDatePicker` of `type="time"` for time selection.
- Formatted the selected time to `HH:mm` format and ensured it is sent to the API upon saving.
- Added functionality to convert the selected time to the correct format when the save button is clicked, before sending it to the API.

#### Benefits:
- Improved user experience by allowing easier time selection.
- Time data is sent to the API in a consistent format, ensuring smooth processing.