### PR TITLE
[small] Feature/012-additional bugFix コード修正

### DIFF
--- a/src/components/ScheduleView.vue
+++ b/src/components/ScheduleView.vue
@@ -11,7 +11,6 @@
         :special-hours="specialHours"
         :events="events"
         class="vuecal--blue-theme vuecal--date-picker demo"
-        xsmall
         :selected-date="selectedDate"
         hide-view-selector
         :transitions="false"
@@ -195,7 +194,7 @@ export default {
       this.selectedEventContents = "";
       this.selectedEventStartTime = "";
       this.selectedEventEndTime = "";
-      this.selectedDate = "";
+      this.selectedDate = new Date().toISOString().split("T")[0];
       this.isEdit = false;
       this.createDialog = true;
     },
@@ -308,25 +307,24 @@ export default {
       }
     },
     async deleteEvent(selectedEventId) {
-      try {
-        const eventId = this.selectedEventId;
-        console.log(eventId);
+      const eventId = this.selectedEventId;
+      console.log(eventId);
 
-        // API呼び出しでイベントを削除
-        await apiFacade.deleteActivity(eventId);
-
-        // 一覧を再取得して画面を更新
-        await this.fetchActivities();
-
-        console.log("イベントを削除しました。");
-
-        // ダイアログを閉じる
-        this.editDialog = false;
-      } catch (error) {
-        console.error("イベントの削除中にエラーが発生しました:", error);
-        alert("イベントの削除に失敗しました。");
-      }
+      // API呼び出しでイベントを削除
+      await apiFacade
+        .deleteActivity(eventId)
+        .then(() => {
+          return this.fetchActivities(); // 成功したら再取得して一覧を更新
+        })
+        .then(() => {
+          this.editDialog = false; // ダイアログを閉じる
+        })
+        .catch((error) => {
+          console.error("イベントの削除中にエラーが発生しました", error); // エラーハンドリング
+          alert("イベントの削除に失敗しました。");
+        });
     },
+
     // 時間をHH:mm形式に変換して格納
     formatTime(timeObj, type) {
       if (timeObj && timeObj.hours !== undefined) {


### PR DESCRIPTION
## 変更内容
- 新規作成画面で、デフォルトの日付として当日を設定することで既存の不具合を修正しました。
- カレンダーコンポーネント (`vue-cal`) の選択日付とデータバインディングを調整し、日付表示が適切に動作するようにしました。
- `deleteEven` の書き方を修正し、コードの可読性と動作を改善しました。
- `VueCal` のオプションから `xsmall` を削除することでエラーを回避しました。

## テスト内容
- デフォルトで当日の日付が表示されることを確認。
- カレンダーで選択した日付が正しく反映されることを確認。
- `deleteEven` の修正が正しく機能することを確認。
- `xsmall` の削除後もカレンダーが正常に動作することを確認。



## Changes
- Fixed an existing issue by setting the default date to the current date in the new creation screen.
- Adjusted the date binding and behavior of the `vue-cal` calendar component to ensure proper date display.
- Refactored the `deleteEven` method to improve readability and functionality.
- Removed the `xsmall` option from `VueCal` to avoid errors.

## Testing
- Verified that the current date is displayed as the default.
- Confirmed that the selected date on the calendar is correctly reflected.
- Ensured the `deleteEven` method works as intended after the modification.
- Verified that removing the `xsmall` option does not affect calendar functionality.
