### PR TITLE
feature/027 UIの絵文字追加と無視リストにアンドロイド関連生成物

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,10 @@ dist-ssr
 
 # 環境変数ファイルを無視
 .env
+
+# Android build files
+android/app/build/
+android/build/
+android/.gradle/
+android/local.properties
+android/capacitor-cordova-android-plugins/build/

--- a/src/components/AnalyzeView.vue
+++ b/src/components/AnalyzeView.vue
@@ -1,5 +1,10 @@
 <template>
   <div class="analyze-container">
+    <!-- ヘッダーセクション -->
+    <div class="analyze-header">
+      <h2>📊 生活記録分析</h2>
+    </div>
+    
     <div v-if="loading" class="loading-screen">
       <div class="loading-content">
         <div class="spinner"></div>
@@ -239,6 +244,23 @@ export default {
   display: flex;
   flex-direction: column;
   gap: 20px;
+}
+
+.analyze-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+  padding-bottom: 15px;
+  border-bottom: 2px solid #e0e0e0;
+}
+
+.analyze-header h2 {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 600;
+  color: #333;
+  font-family: "Poppins", sans-serif;
 }
 
 .filter-section {

--- a/src/components/MoodView.vue
+++ b/src/components/MoodView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="mood-view">
     <div class="mood-header">
-      <h2>気分記録</h2>
+      <h2>📝 気分記録</h2>
       <v-btn color="primary" @click="showMoodDialog = true" class="btn-rounded">
         気分を記録
       </v-btn>

--- a/src/components/ScheduleView.vue
+++ b/src/components/ScheduleView.vue
@@ -3,7 +3,7 @@
     <div class="content-container">
       <div class="button-container">
         <div class="button-group">
-          <h4 class="button-group-title">記録</h4>
+          <h4 class="button-group-title">📝 記録</h4>
           <div class="button-group-content">
             <v-btn color="primary" @click="newCreate" class="btn-rounded">
               新規記録
@@ -19,7 +19,7 @@
         </div>
         
         <div class="button-group">
-          <h4 class="button-group-title">分析</h4>
+          <h4 class="button-group-title">📊 分析</h4>
           <div class="button-group-content">
             <v-btn
               color="secondary"


### PR DESCRIPTION
---

## PRタイトル案
Androidビルド成果物の.gitignore追加＆UI改善（絵文字・ヘッダー追加）

---

## PR説明文（例）

### 概要
- Androidビルド成果物（`android/app/build/` など）を `.gitignore` に追加し、
- リポジトリに不要なファイルがコミットされないようにしました。
- 生活記録分析ページにヘッダー（タイトル）を追加し、気分記録ページとデザインを統一しました。
- 記録・分析ボタンやタイトルに絵文字を追加し、UIの視認性・直感性を向上させました。
- サイドバーの絵文字は要望により削除しました。

### 変更内容
- `.gitignore` に以下を追加
  - `android/app/build/`
  - `android/build/`
  - `android/.gradle/`
  - `android/local.properties`
  - `android/capacitor-cordova-android-plugins/build/`
- `src/components/AnalyzeView.vue`  
  - ヘッダー（「📊 生活記録分析」）追加
  - スタイル追加
- `src/components/ScheduleView.vue`, `src/components/MoodView.vue`, `src/components/Sidebar.vue`
  - ボタンやタイトルに絵文字追加・サイドバーの絵文字削除

### 補足
- Androidビルド成果物は今後コミット不要です。  
- 既にリポジトリに追加されていた場合は、`git rm --cached` で削除してください。
- `.env` など機密情報も引き続きコミットしない運用です。

---