### PR TITLE
Feature/029

### DIFF
--- a/src/components/ScheduleView.vue
+++ b/src/components/ScheduleView.vue
@@ -1246,7 +1246,64 @@ export default {
               year: weekStart.getFullYear(),
               month: weekStart.getMonth(),
               startDate: weekStart,
-              weekDates: weekDates
+              weekDates: weekDates,
+              hasWeekDates: true,
+              weekDatesLength: weekDates.length
+            };
+          }
+        }
+        
+        // 単一月の週の形式 "August 11-17, 2025" の処理
+        const singleMonthMatch = titleText.match(/([A-Za-z]+)\s+(\d+)-(\d+),\s+(\d{4})/);
+        if (singleMonthMatch && singleMonthMatch.length >= 5) {
+          console.log('🔄 単一月の週のフォーマットを検出:', singleMonthMatch);
+          
+          const month = this.getMonthNumberFromName(singleMonthMatch[1]);
+          const startDay = parseInt(singleMonthMatch[2], 10);
+          const endDay = parseInt(singleMonthMatch[3], 10);
+          const year = parseInt(singleMonthMatch[4], 10);
+          
+          console.log(`🗓️ 解析結果: 月=${month+1}, 開始日=${startDay}, 終了日=${endDay}, 年=${year}`);
+          
+          if (!isNaN(month) && !isNaN(startDay) && !isNaN(endDay) && !isNaN(year)) {
+            // 実際の週の開始日を決定する
+            const firstDisplayedDay = new Date(year, month, startDay);
+            let weekStart;
+            
+            // ヘッダーに表示されている最初の日の曜日を取得
+            const firstDayOfWeek = firstDisplayedDay.getDay(); // 0=日曜, 1=月曜, ...
+            
+            if (firstDayOfWeek === 0) {
+              // 日曜日から始まる週の場合、そのまま使用
+              weekStart = new Date(firstDisplayedDay);
+            } else if (firstDayOfWeek === 1) {
+              // 月曜日から始まる週の場合、そのまま使用
+              weekStart = new Date(firstDisplayedDay);
+            } else {
+              // それ以外の場合、表示されている週の日曜日を計算
+              weekStart = new Date(firstDisplayedDay);
+              weekStart.setDate(startDay - firstDayOfWeek);
+            }
+            
+            console.log('📅 単一月の週の開始日:', weekStart);
+            
+            const weekDates = Array.from({ length: 7 }, (_, i) => {
+              const date = new Date(weekStart);
+              date.setDate(weekStart.getDate() + i);
+              return date;
+            });
+            
+            console.log('📆 単一月の週の日付:', 
+              weekDates.map(date => date.toISOString().split('T')[0])
+            );
+            
+            return {
+              year: weekStart.getFullYear(),
+              month: month,
+              startDate: weekStart,
+              weekDates: weekDates,
+              hasWeekDates: true,
+              weekDatesLength: weekDates.length
             };
           }
         }
@@ -1275,7 +1332,9 @@ export default {
         year: currentDate.getFullYear(),
         month: currentDate.getMonth(),
         startDate: new Date(currentDate.getFullYear(), currentDate.getMonth(), 1),
-        weekDates: null // 週の日付が特定できない場合はnull
+        weekDates: null, // 週の日付が特定できない場合はnull
+        hasWeekDates: false,
+        weekDatesLength: 0
       };
     },
     

--- a/src/components/ScheduleView.vue
+++ b/src/components/ScheduleView.vue
@@ -1138,7 +1138,7 @@ export default {
         } catch (error) {
           console.error('Error setting up header date clicks:', error);
         }
-      }, 100); // 100ms遅延させてDOM更新を待つ
+      });
     },
     
     /**

--- a/src/components/ScheduleView.vue
+++ b/src/components/ScheduleView.vue
@@ -74,6 +74,10 @@
         @event-click="handleDateClick"
         @view-change="setupHeaderDateClicks"
         @click-on-date="onDateChanged"
+        @ready="setupHeaderDateClicks"
+        @next="setupHeaderDateClicks"
+        @previous="setupHeaderDateClicks"
+        @today="setupHeaderDateClicks"
       >
       </vue-cal>
 
@@ -681,12 +685,19 @@ export default {
 
     handleCellClick(cellData) {
       // ヘッダークリック時はDate型、セルクリック時はcellオブジェクト
+      console.log('🎯 handleCellClick呼び出し:', cellData);
       let dateObj;
 
       if (cellData instanceof Date) {
         // ヘッダークリック
         dateObj = cellData;
-        console.log('Header date clicked:', dateObj);
+        console.log('📅 ヘッダー日付がクリックされました:', {
+          date: dateObj.toISOString().split('T')[0],
+          year: dateObj.getFullYear(),
+          month: dateObj.getMonth() + 1,
+          day: dateObj.getDate(),
+          weekday: ['日', '月', '火', '水', '木', '金', '土'][dateObj.getDay()]
+        });
       } else if (cellData && cellData.cell && cellData.cell.date) {
         // セルクリック
         dateObj = cellData.cell.date;
@@ -999,101 +1010,301 @@ export default {
     
     /**
      * Vue-Cal v5のヘッダー日付要素にクリックイベントを追加する
-     * カレンダーレンダリング後に呼び出される
+     * カレンダーレンダリング後や表示変更時に呼び出される
      */
     setupHeaderDateClicks() {
-      // ヘッダー日付要素を取得
-      const weekdayElements = document.querySelectorAll('.vuecal--custom-theme .vuecal__weekday');
-      
-      // 直接Vue-Calから現在表示されている日付の範囲を取得
-      const vuecalElement = document.querySelector('.vuecal');
-      let startDate = null;
-      
-      // Vue-Cal要素からデータ属性を使って現在の日付を取得
-      if (vuecalElement && vuecalElement.__vue__) {
-        startDate = vuecalElement.__vue__.view.startDate;
-        console.log('Vue-Cal start date:', startDate);
-      }
-      
-      if (weekdayElements.length > 0) {
-        console.log('Vue-Cal weekday headers found:', weekdayElements.length);
-        
-        // 各ヘッダー日付要素にクリックイベントを追加
-        weekdayElements.forEach((element, index) => {
-          element.addEventListener('click', (e) => {
-            try {
-              // 要素から日付テキストを取得
-              const dateText = element.querySelector('.vuecal__weekday-date')?.innerText || '';
-              console.log('Clicked on weekday element with text:', dateText);
-              
-              // カレンダー要素から直接日付を取得
-              const vuecalInstance = document.querySelector('.vuecal')?.__vue__;
-              let clickDate;
-              
-              if (vuecalInstance && vuecalInstance.view && vuecalInstance.view.startDate) {
-                // Vue-Calインスタンスから週の開始日を取得
-                const weekStart = new Date(vuecalInstance.view.startDate);
-                
-                // 今選択しているindexに基づいて日付を取得
-                clickDate = new Date(weekStart);
-                clickDate.setDate(weekStart.getDate() + index);
-                console.log(`Using Vue-Cal instance: weekStart=${weekStart}, index=${index}, clickDate=${clickDate}`);
-              } else {
-                // テキストから日付を取得（フォールバック）
-                if (dateText && !isNaN(parseInt(dateText))) {
-                  const dayOfMonth = parseInt(dateText);
-                  // 現在のVue-Calの表示月を使用する
-                  // カレンダー内のセルから日付オブジェクトを取得できるか試みる
-                  const dateCell = document.querySelector('.vuecal__cell--today');
-                  let year = new Date().getFullYear();
-                  let month = new Date().getMonth();
-                  
-                  if (dateCell && dateCell.__vue__ && dateCell.__vue__.data) {
-                    year = dateCell.__vue__.data.date.getFullYear();
-                    month = dateCell.__vue__.data.date.getMonth();
-                  }
-                  
-                  clickDate = new Date(year, month, dayOfMonth);
-                  console.log(`Using text date: year=${year}, month=${month}, day=${dayOfMonth}, clickDate=${clickDate}`);
-                } else {
-                  // どうしても取得できない場合は現在の日付を使用
-                  clickDate = new Date();
-                  console.warn('Failed to get date from element, using current date:', clickDate);
-                }
-              }
-              
-              console.log('Final header date clicked:', clickDate, 'Date text:', dateText);
-              this.handleCellClick(clickDate);
-            } catch (error) {
-              console.error('Error in weekday click handler:', error);
-              // エラーが発生した場合は今日の日付を使用
-              const today = new Date();
-              this.handleCellClick(today);
+      // DOM更新を待つために少し遅延させる
+      setTimeout(() => {
+        try {
+          console.log('Setting up header date clicks');
+          
+          // ヘッダー要素を取得（複数のセレクタを試す）
+          let weekdayElements = document.querySelectorAll('.vuecal--custom-theme .vuecal__weekday');
+          
+          // もし見つからない場合は別のセレクタを試す
+          if (weekdayElements.length === 0) {
+            weekdayElements = document.querySelectorAll('.vuecal--week-view .vuecal__heading');
+          }
+          
+          // それでも見つからない場合は他のセレクタを試す
+          if (weekdayElements.length === 0) {
+            weekdayElements = document.querySelectorAll('.vuecal__flex .vuecal__heading');
+          }
+          
+          if (weekdayElements.length === 0) {
+            console.warn('Vue-Cal weekday headers not found');
+            return;
+          }
+          
+          console.log('Vue-Cal weekday headers found:', weekdayElements.length);
+          
+          // 各ヘッダー日付要素にクリックイベントを追加
+          weekdayElements.forEach((element, index) => {
+            // イベントリスナーをクリアするために要素をクローン
+            const newElement = element.cloneNode(true);
+            if (element.parentNode) {
+              element.parentNode.replaceChild(newElement, element);
             }
             
-            // イベントの伝播を止める
-            e.stopPropagation();
-          }, { capture: true }); // キャプチャフェーズでイベントを処理
-        });
-      } else {
-        console.warn('Vue-Cal weekday headers not found');
-      }
+            // クリックイベントリスナーを追加
+            newElement.addEventListener('click', (e) => {
+              try {
+                console.log(`🖱️ ヘッダー要素 ${index} がクリックされました`);
+                
+                // カレンダー要素から直接日付を取得
+                const vuecalInstance = document.querySelector('.vuecal')?.__vue__;
+                let clickDate;
+                
+                if (vuecalInstance && vuecalInstance.view && vuecalInstance.view.startDate) {
+                  // Vue-Calインスタンスから週の開始日を取得
+                  const weekStart = new Date(vuecalInstance.view.startDate);
+                
+                  // インデックスに基づいて日付を計算
+                  clickDate = new Date(weekStart);
+                  clickDate.setDate(weekStart.getDate() + index);
+                  console.log(`Using Vue-Cal instance: weekStart=${weekStart}, index=${index}, clickDate=${clickDate}`);
+                } else {
+                  // 要素から日付テキストを取得（フォールバック）
+                  const dateText = newElement.querySelector('.vuecal__weekday-date')?.innerText || '';
+                  
+                  if (dateText && !isNaN(parseInt(dateText))) {
+                    const dayOfMonth = parseInt(dateText);
+                    
+                    // 現在のカレンダー情報を取得
+                    const calendarInfo = this.getCurrentCalendarInfo();
+                    
+                    // 現在のカレンダー情報を詳細に出力
+                    console.log('🔍 取得したカレンダー情報:', {
+                      year: calendarInfo.year,
+                      month: calendarInfo.month + 1,
+                      startDate: calendarInfo.startDate?.toISOString(),
+                      hasWeekDates: !!calendarInfo.weekDates,
+                      weekDatesLength: calendarInfo.weekDates?.length || 0
+                    });
+                    
+                    // 週の日付情報が利用可能な場合はそれを使用
+                    if (calendarInfo.weekDates && calendarInfo.weekDates.length > 0) {
+                      // 週の表示形式に応じてインデックスを調整
+                      const adjustedIndex = index % 7; // 7で割った余りを使用（週の中での相対位置）
+                      
+                      console.log(`🔢 インデックス調整: 元のindex=${index}, 調整後index=${adjustedIndex}, ヘッダーテキスト=${dateText}`);
+                      
+                      if (adjustedIndex < calendarInfo.weekDates.length) {
+                        // 調整したインデックスに対応する週の日付を使用
+                        clickDate = new Date(calendarInfo.weekDates[adjustedIndex]);
+                        console.log(`✅ 週の日付配列を使用: adjustedIndex=${adjustedIndex}, clickDate=${clickDate.toISOString().split('T')[0]}`);
+                      } else {
+                        // インデックスが範囲外の場合のフォールバック
+                        console.log(`⚠️ 調整後インデックス ${adjustedIndex} が週の日付配列の範囲外です`);
+                        const currentYear = calendarInfo.year;
+                        const currentMonth = calendarInfo.month;
+                        clickDate = new Date(currentYear, currentMonth, dayOfMonth);
+                      }
+                    } else {
+                      // 週の日付情報がない場合の従来のフォールバック
+                      const currentYear = calendarInfo.year;
+                      const currentMonth = calendarInfo.month;
+                      
+                      // 日付オブジェクトを作成
+                      clickDate = new Date(currentYear, currentMonth, dayOfMonth);
+                      console.log(`⚠️ 従来のフォールバック: year=${currentYear}, month=${currentMonth+1}, day=${dayOfMonth}, clickDate=${clickDate.toISOString().split('T')[0]}`);
+                    }
+                  } else {
+                    // どうしても取得できない場合は今日の日付を使用
+                    clickDate = new Date();
+                    console.warn('Failed to get date from element, using current date:', clickDate);
+                  }
+                }
+                
+                console.log('✅ 最終的なヘッダー日付クリック:', {
+                  date: clickDate.toISOString().split('T')[0],
+                  year: clickDate.getFullYear(),
+                  month: clickDate.getMonth() + 1,
+                  day: clickDate.getDate(),
+                  weekday: ['日', '月', '火', '水', '木', '金', '土'][clickDate.getDay()]
+                });
+                this.handleCellClick(clickDate);
+              } catch (error) {
+                console.error('Error in weekday click handler:', error);
+                // エラーが発生した場合は今日の日付を使用
+                const today = new Date();
+                this.handleCellClick(today);
+              }
+              
+              // イベントの伝播を止める
+              e.stopPropagation();
+            }, { capture: true });
+          });
+        } catch (error) {
+          console.error('Error setting up header date clicks:', error);
+        }
+      }, 100); // 100ms遅延させてDOM更新を待つ
     },
     
     /**
-     * 現在表示されている週の開始日を取得
-     * @returns {Date} 週の開始日
+     * 現在のカレンダーの週情報を取得する
+     * 週表示で月をまたぐ場合にも正確な日付を返す
      */
-    getWeekStartDate() {
-      // 現在選択されている日付から週の開始日を計算
-      const date = this.selectedDate ? new Date(this.selectedDate) : new Date();
-      console.log(this.selectedDates)
-      const day = date.getDay(); // 0:日曜, 1:月曜, ...
-      const diff = date.getDate() - day; // 週の開始日（日曜日）を計算
+    getCurrentCalendarInfo() {
+      console.log('🔍 getCurrentCalendarInfo: カレンダー情報の取得を開始');
       
-      // 新しいDateオブジェクトを作成して元の日付を変更しないようにする
-      const result = new Date(date);
-      result.setDate(diff);
+      // 基本的にはVue-Calのインスタンスから週の開始日を取得
+      const vuecalInstance = document.querySelector('.vuecal')?.__vue__;
+      if (vuecalInstance && vuecalInstance.view && vuecalInstance.view.startDate) {
+        // 週の開始日を取得
+        const weekStart = new Date(vuecalInstance.view.startDate);
+        console.log('📅 Vue-Calから週の開始日を取得:', weekStart);
+        console.log('🔎 現在のビュー:', vuecalInstance.currentView);
+        
+        // 現在のビューに関する追加情報
+        if (vuecalInstance.cells && vuecalInstance.cells.length > 0) {
+          console.log('📊 セル情報:', 
+            vuecalInstance.cells.map(cell => ({
+              date: cell.date, 
+              content: cell.content,
+              events: cell.events?.length || 0
+            }))
+          );
+        }
+        
+        // 現在の日付から取得（週の最初の日の情報を使用）
+        const weekDates = Array.from({ length: 7 }, (_, i) => {
+          const date = new Date(weekStart);
+          date.setDate(weekStart.getDate() + i);
+          return date;
+        });
+        
+        console.log('📆 計算された週の日付:', 
+          weekDates.map(date => date.toISOString().split('T')[0])
+        );
+        
+        return {
+          year: weekStart.getFullYear(),
+          month: weekStart.getMonth(),
+          startDate: weekStart,
+          weekDates: weekDates
+        };
+      }
+      
+      // フォールバック: Vue-Calから情報を取得できない場合
+      console.log('⚠️ Vue-Calインスタンスから情報を取得できないためフォールバック');
+      
+      let currentDate = new Date();
+      const calendarHeaderEl = document.querySelector('.vuecal--custom-theme .vuecal__title');
+      
+      if (calendarHeaderEl) {
+        // カレンダーのタイトルから情報を抽出（フォールバック）
+        const titleText = calendarHeaderEl.textContent || '';
+        console.log('📝 カレンダータイトルのテキスト:', titleText);
+        
+        // "Jul 28 - Aug 3, 2025" のような形式も処理（月をまたぐ週の場合）
+        const crossMonthMatch = titleText.match(/([A-Za-z]+)\s+(\d+)\s+-\s+([A-Za-z]+)\s+(\d+),\s+(\d{4})/);
+        if (crossMonthMatch && crossMonthMatch.length >= 6) {
+          console.log('🔄 月をまたぐ週のフォーマットを検出:', crossMonthMatch);
+          
+          const startMonth = this.getMonthNumberFromName(crossMonthMatch[1]);
+          const startDay = parseInt(crossMonthMatch[2], 10);
+          const endMonth = this.getMonthNumberFromName(crossMonthMatch[3]);
+          const endDay = parseInt(crossMonthMatch[4], 10);
+          const year = parseInt(crossMonthMatch[5], 10);
+          
+          console.log(`🗓️ 解析結果: 開始=${startMonth+1}月${startDay}日, 終了=${endMonth+1}月${endDay}日, 年=${year}`);
+          
+          if (!isNaN(startMonth) && !isNaN(startDay) && !isNaN(endMonth) && !isNaN(endDay) && !isNaN(year)) {
+            // 実際の週の開始日を決定する（日曜日または月曜日から始まる週）
+            const firstDisplayedDay = new Date(year, startMonth, startDay);
+            let weekStart;
+            
+            // ヘッダーに表示されている最初の日の曜日を取得
+            const firstDayOfWeek = firstDisplayedDay.getDay(); // 0=日曜, 1=月曜, ...
+            
+            if (firstDayOfWeek === 0) {
+              // 日曜日から始まる週の場合、そのまま使用
+              weekStart = new Date(firstDisplayedDay);
+            } else if (firstDayOfWeek === 1) {
+              // 月曜日から始まる週の場合、そのまま使用
+              weekStart = new Date(firstDisplayedDay);
+            } else {
+              // それ以外の場合、表示されている週の日曜日を計算
+              weekStart = new Date(firstDisplayedDay);
+              weekStart.setDate(startDay - firstDayOfWeek);
+            }
+            
+            console.log('📅 実際の週の開始日:', weekStart);
+            
+            const weekDates = Array.from({ length: 7 }, (_, i) => {
+              const date = new Date(weekStart);
+              date.setDate(weekStart.getDate() + i);
+              return date;
+            });
+            
+            console.log('📆 月をまたぐ週の日付:', 
+              weekDates.map(date => date.toISOString().split('T')[0])
+            );
+            
+            return {
+              year: weekStart.getFullYear(),
+              month: weekStart.getMonth(),
+              startDate: weekStart,
+              weekDates: weekDates
+            };
+          }
+        }
+        
+        // 標準的な形式 "2025年7月" の処理
+        const standardMatch = titleText.match(/(\d{4})年(\d{1,2})月/);
+        if (standardMatch && standardMatch.length >= 3) {
+          console.log('📅 標準的な年月フォーマットを検出:', standardMatch);
+          
+          const year = parseInt(standardMatch[1], 10);
+          const month = parseInt(standardMatch[2], 10) - 1; // JavaScriptの月は0始まり
+          
+          if (!isNaN(year) && !isNaN(month)) {
+            currentDate = new Date(year, month, 1);
+            console.log('📆 標準フォーマットから取得した年月:', year, '年', month + 1, '月');
+          }
+        }
+      } else {
+        console.log('⚠️ カレンダータイトル要素が見つかりません');
+      }
+      
+      // どの方法でも情報が取得できなかった場合は現在の日付を使用
+      console.log('🔄 フォールバック: 現在の日付を使用します:', currentDate);
+      
+      return {
+        year: currentDate.getFullYear(),
+        month: currentDate.getMonth(),
+        startDate: new Date(currentDate.getFullYear(), currentDate.getMonth(), 1),
+        weekDates: null // 週の日付が特定できない場合はnull
+      };
+    },
+    
+    /**
+     * 月名から月番号を取得する (0-based)
+     * @param {string} monthName - 月の名前 (Jan, February など)
+     * @returns {number} 月の番号 (0-11)、不明な場合は -1
+     */
+    getMonthNumberFromName(monthName) {
+      if (!monthName) return -1;
+      
+      const monthNames = {
+        jan: 0, january: 0,
+        feb: 1, february: 1,
+        mar: 2, march: 2,
+        apr: 3, april: 3,
+        may: 4,
+        jun: 5, june: 5,
+        jul: 6, july: 6,
+        aug: 7, august: 7,
+        sep: 8, september: 8,
+        oct: 9, october: 9,
+        nov: 10, november: 10,
+        dec: 11, december: 11
+      };
+      
+      const normalizedName = monthName.toLowerCase().trim();
+      const result = monthNames[normalizedName] !== undefined ? monthNames[normalizedName] : -1;
+      console.log(`🗓️ 月名 "${monthName}" を月番号 ${result} に変換`);
       return result;
     },
     
@@ -1102,6 +1313,8 @@ export default {
      * ヘッダークリックイベントを再設定する
      */
     onDateChanged() {
+      console.log('Date changed, resetting header clicks');
+      // DOM更新を待ってからヘッダークリックイベントを設定
       this.$nextTick(() => {
         this.setupHeaderDateClicks();
       });


### PR DESCRIPTION
---

### 🛠 PRタイトル

**Vue-Cal ヘッダークリック時の日付ズレ問題の修正＋安定性向上対応**

---

### 📝 概要

カレンダーのヘッダー（日付）クリック時に、日付が正しく取得できない問題を解消しました。
また、週や月をまたぐ表示やナビゲーション操作後も正常に動作するよう、関連処理を大幅に改善しています。

---

### ✅ 修正内容の詳細

#### 1. ヘッダークリックイベントの改善

* Vue-Calインスタンスから **正確な週開始日を取得**
* ヘッダーインデックスから日付を **動的に計算**（週表示／月表示に対応）
* **フォールバック処理**とエラーハンドリングを追加し、取得失敗時でも安定動作

#### 2. 気分記録ダイアログのタイトル修正

* `formatDisplayDate` 関数を使い、**正確かつ整形された日付表示**に変更

#### 3. デバッグ情報の強化

* 日付処理の各ステップで **詳細なログ出力**を追加
* 問題解析を容易にするため、Vue-Calの内部状態やインデックス情報も出力

#### 4. ビュー切り替え後のイベント消失問題への対応

* 週／月の表示切り替え、前後ナビゲーション操作後に **`setupHeaderDateClicks` を再実行**
* イベントリスナーの **事前クリア処理**を追加（メモリリーク防止）

#### 5. 日付の計算方法の改善

* 現在のカレンダー表示モードに応じて、**動的に週の開始日・表示日付を算出**
* Vue-Calの状態を常に参照するようにして、ズレのない日付処理を実現

#### 6. バグ耐性の強化

* 例外処理を追加し、何らかの問題が起きてもアプリ全体が落ちないように保護
* **複数のフォールバックロジック**を導入し、最悪のケースでも日付特定を試行

---

### 🔍 目的（修正の意図）

* カレンダーのヘッダークリック時の日付処理を **正確化**
* 複数月にまたがる週表示などの **表示ズレ／クリックズレの修正**
* **クリックイベントが消える問題**の恒久対応

---

### 🔧 影響範囲

* ヘッダークリックによる日付選択処理
* 週・月ビュー切り替え後のカレンダー動作
* 気分記録ダイアログのタイトル表示
* デバッグ／ログ出力部分

---

### ✅ 動作確認リスト

* [x] カレンダーのヘッダークリックで正しい日付が取得できる
* [x] 複数月にまたがる週でも意図通りの日付が選択される
* [x] 月／週の切り替え後でもクリック処理が機能する
* [x] 気分記録ダイアログに正しい日付が表示される
* [x] デバッグログが正しく出力される
* [x] エラー発生時にもアプリが落ちず、処理が継続される

---

### 💡 備考

* 今後の保守性を考慮し、Vue-Calの状態を参照する形で日付ロジックを構成しています
以下のように追記し、ニュアンスを保ちつつ自然な文章に整えました：

---

### 💡 備考

* 今後の保守性を考慮し、Vue-Calの状態を参照する形で日付ロジックを構成しています
* **追加ログは開発中のみ有効化しておく予定ですが、処理がやや複雑なため後々のために残す可能性もあります**
* 特に、**Vue-CalライブラリをDOM経由で“半ば強引に”拡張している部分があるため、意図を明確にするためのログとして残す判断もあり得ます**

---
