### PR TITLE
ScheduleView.vueのイベントデータ検証とフィルタリングの実装

### DIFF
--- a/src/components/ScheduleView.vue
+++ b/src/components/ScheduleView.vue
@@ -579,6 +579,21 @@ export default {
             endDate = new Date(startDate.getTime() + 60 * 60 * 1000); // エラー時はスタート+1時間
           }
           
+          // 無効なデータのチェック: 終了時刻が開始時刻より前の場合
+          if (endDate < startDate) {
+            console.warn('無効なイベントデータを検出:', {
+              activityId: activity.activityId,
+              title: activity.title,
+              start: activity.start,
+              end: activity.end,
+              startDate: startDate.toISOString(),
+              endDate: endDate.toISOString(),
+              reason: '終了時刻が開始時刻より前になっています'
+            });
+            // 無効なデータはnullを返す
+            return null;
+          }
+          
           // カテゴリに基づく背景色の定義
           const categoryColors = {
             '運動': { bg: '#e0f7fa', text: '#01579b' },
@@ -623,7 +638,11 @@ export default {
           return event;
         });
         
-        this.events = transformedEvents;
+        // 無効なデータ（null）をフィルタリング
+        const validEvents = transformedEvents.filter(event => event !== null);
+        console.log(`全${activities.length}件中、有効なイベント: ${validEvents.length}件、無効なイベント: ${activities.length - validEvents.length}件`);
+        
+        this.events = validEvents;
       } catch (error) {
         console.error("Error fetching activities:", error);
         this.events = []; // Set empty array on error


### PR DESCRIPTION
# プルリクエストタイトル
ScheduleView.vueのイベントデータ検証とフィルタリングの実装

## Bugの背景
現在のSBM-APPのフロントバリデーションでは
start > end では登録も更新もできないようになっているが、
過去のデータやバグなどでstart > end となっている場合、不正な値としてカレンダー描画ができない。

そのため下記の対応を行った。 

## 概要
このプルリクエストでは、`ScheduleView.vue`コンポーネントにおいて以下の変更を行いました：
- イベントデータの検証ロジックを追加（終了時刻が開始時刻より早い場合を無効とする）。
- 無効なデータをログに記録し、Vue Calに渡す前にフィルタリング。
- Vue Calに正しいイベントデータが表示されるようデバッグと調整。

## 変更内容
1. **データ検証**:
   - `endDate < startDate` の条件で無効なデータを検出。
   - 無効なデータについて、詳細（アクティビティID、開始/終了時刻、理由）をログに記録。

2. **データフィルタリング**:
   - 無効なデータを`Array.filter`を使用して除外。
   - 有効なデータのみVue Calに渡す。

3. **デバッグと調整**:
   - Vue Calに渡すイベントデータのフォーマットを確認。
   - イベントが正しく表示されるように修正。

## 動作確認
- 無効なデータが検出され、ログに記録されることを確認。
- 有効なデータのみがVue Calに表示されることを確認。
- データ検証とフィルタリングが期待通りに動作することを確認。

## スクリーンショット
（必要に応じてスクリーンショットを追加）

## 関連する課題
- https://github.com/kaminuma/sbm-application_UI/issues/57

## チェックリスト
- [ ] コードが正しく動作することを確認しました。

## 備考
本番で発生したBug Fix