### PR TITLE
UIデプロイをSession Manager + S3方式に移行

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,35 +37,105 @@ jobs:
       - name: Build UI
         run: npm run build
 
-      # 6. 成果物をEC2にデプロイ
-      - name: Deploy to EC2
-        uses: burnett01/rsync-deployments@5.1
+      # 6. AWS認証設定
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          switches: '-avz --delete --rsync-path="sudo rsync"'
-          path: ./dist/ # ローカルの成果物パス
-          remote_path: /srv/sbm/ui/ # EC2のデプロイ先ディレクトリ
-          remote_host: ${{ secrets.HOST }}
-          remote_user: ${{ secrets.USER }}
-          remote_key: ${{ secrets.SECRET_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
-      # 7. サーバーを再起動（Nginxリロード）
-      - name: Restart Nginx
-        uses: appleboy/ssh-action@v0.1.5
-        with:
-          host: ${{ secrets.HOST }}
-          username: ${{ secrets.USER }}
-          key: ${{ secrets.SECRET_KEY }}
-          script: |
-            sudo nginx -t
-            sudo systemctl reload nginx
+      # 7. ビルド成果物のS3アップロード
+      - name: Upload build artifacts to S3
+        run: |
+          # ビルド成果物をS3にアップロード
+          TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+          S3_BUCKET="sbm-deploy-${{ secrets.AWS_REGION }}"
+          S3_KEY="ui-deploys/${TIMESTAMP}/ui-build.tar.gz"
+          
+          # バケットが存在しない場合は作成
+          aws s3 mb "s3://${S3_BUCKET}" --region ${{ secrets.AWS_REGION }} 2>/dev/null || true
+          
+          # ビルド成果物を圧縮してアップロード
+          tar -czf ui-build.tar.gz -C dist .
+          aws s3 cp ui-build.tar.gz "s3://${S3_BUCKET}/${S3_KEY}" --region ${{ secrets.AWS_REGION }}
+          
+          echo "S3_BUCKET=${S3_BUCKET}" >> $GITHUB_ENV
+          echo "S3_KEY=${S3_KEY}" >> $GITHUB_ENV
 
-      # 権限を戻す
-      - name: Reset permissions
-        uses: appleboy/ssh-action@v0.1.5
-        with:
-          host: ${{ secrets.HOST }}
-          username: ${{ secrets.USER }}
-          key: ${{ secrets.SECRET_KEY }}
-          script: |
-            sudo chmod -R 755 /srv/sbm/ui
-            sudo chown -R ${{ secrets.USER }}:${{ secrets.USER }} /srv/sbm/ui
+      # 8. Session Manager経由でのデプロイ
+      - name: Deploy via Session Manager
+        run: |
+          # Session Manager経由でS3からダウンロード・配置
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids ${{ secrets.EC2_INSTANCE_ID }} \
+            --document-name "AWS-RunShellScript" \
+            --parameters "commands=[
+              \"sudo systemctl stop nginx || true\",
+              \"aws s3 cp s3://${{ env.S3_BUCKET }}/${{ env.S3_KEY }} /tmp/ui-build.tar.gz\",
+              \"sudo rm -rf /srv/sbm/ui/* || true\",
+              \"sudo tar -xzf /tmp/ui-build.tar.gz -C /srv/sbm/ui/\",
+              \"sudo chmod -R 755 /srv/sbm/ui\",
+              \"sudo chown -R ${{ secrets.USER }}:${{ secrets.USER }} /srv/sbm/ui\",
+              \"rm /tmp/ui-build.tar.gz\"
+            ]" \
+            --region ${{ secrets.AWS_REGION }} \
+            --output text --query "Command.CommandId")
+          
+          # コマンド実行完了を待機
+          aws ssm wait command-executed \
+            --command-id $COMMAND_ID \
+            --instance-id ${{ secrets.EC2_INSTANCE_ID }} \
+            --region ${{ secrets.AWS_REGION }}
+          
+          # 実行結果を確認
+          STATUS=$(aws ssm get-command-invocation \
+            --command-id $COMMAND_ID \
+            --instance-id ${{ secrets.EC2_INSTANCE_ID }} \
+            --region ${{ secrets.AWS_REGION }} \
+            --output text --query "Status")
+          
+          if [ "$STATUS" != "Success" ]; then
+            echo "UI deployment failed with status: $STATUS"
+            exit 1
+          fi
+
+      # 9. Webサーバー再起動
+      - name: Restart web server via Session Manager
+        run: |
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids ${{ secrets.EC2_INSTANCE_ID }} \
+            --document-name "AWS-RunShellScript" \
+            --parameters 'commands=["sudo nginx -t","sudo systemctl start nginx","sudo systemctl reload nginx"]' \
+            --region ${{ secrets.AWS_REGION }} \
+            --output text --query "Command.CommandId")
+          
+          # コマンド実行完了を待機
+          aws ssm wait command-executed \
+            --command-id $COMMAND_ID \
+            --instance-id ${{ secrets.EC2_INSTANCE_ID }} \
+            --region ${{ secrets.AWS_REGION }}
+          
+          # 実行結果を確認
+          STATUS=$(aws ssm get-command-invocation \
+            --command-id $COMMAND_ID \
+            --instance-id ${{ secrets.EC2_INSTANCE_ID }} \
+            --region ${{ secrets.AWS_REGION }} \
+            --output text --query "Status")
+          
+          if [ "$STATUS" != "Success" ]; then
+            echo "Web server restart failed with status: $STATUS"
+            exit 1
+          fi
+
+      # 10. S3クリーンアップ（オプション）
+      - name: Clean up old S3 files
+        run: |
+          # 7日以上前のデプロイファイルを削除
+          aws s3 rm "s3://${{ env.S3_BUCKET }}/ui-deploys/" \
+            --recursive \
+            --region ${{ secrets.AWS_REGION }} \
+            --exclude "*" \
+            --include "ui-deploys/*" \
+            --exclude "ui-deploys/$(date -d '7 days ago' +%Y%m%d)*" || true
+            

--- a/.github/workflows/release_old_uses_ssh.yml.disabled
+++ b/.github/workflows/release_old_uses_ssh.yml.disabled
@@ -1,0 +1,71 @@
+name: Build and Deploy UI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy-ui:
+    runs-on: ubuntu-latest
+    environment: prod
+
+    steps:
+      # 1. リポジトリをチェックアウト
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # 2. Node.jsのセットアップ
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+
+      # 3. 環境変数を設定
+      - name: Configure environment variables
+        run: |
+          # 既存の値を置き換える
+          sed -i "s|^VITE_API_BASE_URL=.*|VITE_API_BASE_URL=${{ secrets.API_BASE_URL }}|" .env
+          sed -i "s|^VITE_BASE_URL=.*|VITE_BASE_URL=${{ secrets.BASE_URL }}|" .env
+          sed -i "s|^VITE_OAUTH2_BASE_URL=.*|VITE_OAUTH2_BASE_URL=${{ secrets.OAUTH2_BASE_URL }}|" .env
+
+      # 4. 依存関係のインストール
+      - name: Install dependencies
+        run: npm ci
+
+      # 5. ビルド
+      - name: Build UI
+        run: npm run build
+
+      # 6. 成果物をEC2にデプロイ
+      - name: Deploy to EC2
+        uses: burnett01/rsync-deployments@5.1
+        with:
+          switches: '-avz --delete --rsync-path="sudo rsync"'
+          path: ./dist/ # ローカルの成果物パス
+          remote_path: /srv/sbm/ui/ # EC2のデプロイ先ディレクトリ
+          remote_host: ${{ secrets.HOST }}
+          remote_user: ${{ secrets.USER }}
+          remote_key: ${{ secrets.SECRET_KEY }}
+
+      # 7. サーバーを再起動（Nginxリロード）
+      - name: Restart Nginx
+        uses: appleboy/ssh-action@v0.1.5
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USER }}
+          key: ${{ secrets.SECRET_KEY }}
+          script: |
+            sudo nginx -t
+            sudo systemctl reload nginx
+
+      # 権限を戻す
+      - name: Reset permissions
+        uses: appleboy/ssh-action@v0.1.5
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USER }}
+          key: ${{ secrets.SECRET_KEY }}
+          script: |
+            sudo chmod -R 755 /srv/sbm/ui
+            sudo chown -R ${{ secrets.USER }}:${{ secrets.USER }} /srv/sbm/ui


### PR DESCRIPTION
## Summary
• SSH22ポート不要のセキュアなデプロイ方式に変更
• AWS Systems Manager Session Manager経由でEC2を操作
• S3を経由してビルド成果物を安全に転送
• 既存SSH設定（rsync-deployments, ssh-action）を完全削除

## 主な変更点
• Session Manager + S3デプロイ方式への完全移行
• エラーハンドリングとS3クリーンアップ機能追加
• 既存ワークフローをバックアップとして保存
• セキュリティ強化（SSH22ポート不要）

## Test plan
- [ ] GitHub Actions ワークフローの正常実行確認
- [ ] S3へのビルド成果物アップロード確認
- [ ] Session Manager経由でのEC2デプロイ確認
- [ ] Webサーバー再起動とサービス動作確認
- [ ] デプロイ完了後のサイト動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)