### PR TITLE
chore: vue-cal v5.0.1-rc.28へのアップデートとバージョン更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sbm-application-ui",
-  "version": "0.0.4-SNAPSHOT",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sbm-application-ui",
-      "version": "0.0.4-SNAPSHOT",
+      "version": "0.4.1",
       "dependencies": {
         "@mdi/font": "^7.4.47",
         "@vuepic/vue-datepicker": "^9.0.3",
@@ -15,7 +15,7 @@
         "echarts": "^5.6.0",
         "material-design-icons-iconfont": "^6.7.0",
         "vue": "^3.5.17",
-        "vue-cal": "^5.0.1-rc.25",
+        "vue-cal": "^5.0.1-rc.28",
         "vue-chartjs": "^5.3.2",
         "vue-echarts": "^7.0.3",
         "vue-router": "^4.5.1",
@@ -3884,9 +3884,9 @@
       }
     },
     "node_modules/vue-cal": {
-      "version": "5.0.1-rc.25",
-      "resolved": "https://registry.npmjs.org/vue-cal/-/vue-cal-5.0.1-rc.25.tgz",
-      "integrity": "sha512-aUzJuu2mJJYIA8sYiy+JFYUowhoeZFDqIZrds7fm9j+2/A3GNn9lwPyUFoJql7FuaNUkQ/GkcRsgjKe8Y9b92w==",
+      "version": "5.0.1-rc.28",
+      "resolved": "https://registry.npmjs.org/vue-cal/-/vue-cal-5.0.1-rc.28.tgz",
+      "integrity": "sha512-rc4nGXdNFX1VbCqsdiVPeLR5oE9XLzJZ+lLBYfLZfnVjibZE2KYTQ7Ro7gx1s4ECqOMwG5U0frSMQpBpQpTFSQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antoniandre"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "echarts": "^5.6.0",
     "material-design-icons-iconfont": "^6.7.0",
     "vue": "^3.5.17",
-    "vue-cal": "^5.0.1-rc.25",
+    "vue-cal": "^5.0.1-rc.28",
     "vue-chartjs": "^5.3.2",
     "vue-echarts": "^7.0.3",
     "vue-router": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sbm-application-ui",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- vue-calをv5.0.1-rc.25からv5.0.1-rc.28に更新
- パッケージバージョンを0.4.3に更新

## Changes
- `package.json`: vue-calライブラリの更新
- `package.json`: アプリケーションバージョンの更新

## Test plan
- [x] vue-calの互換性チェック完了（破壊的変更なし）
- [x] 開発環境での動作確認
- [x] カレンダー機能の動作テスト

🤖 Generated with [Claude Code](https://claude.ai/code)