### PR TITLE
fix: APIレスポンスのフィールド名不一致を修正

### DIFF
--- a/src/components/AIAnalysisView.vue
+++ b/src/components/AIAnalysisView.vue
@@ -316,11 +316,12 @@ export default {
       try {
         const response = await apiFacade.getAIUsage()
         if (response.success) {
+          // APIからのレスポンスのフィールド名に合わせる（キャメルケース）
           this.aiUsageInfo = {
-            dailyUsed: response.data.daily_usage || 0,
-            dailyLimit: response.data.daily_limit || 5,
-            remainingToday: response.data.remaining_usage || 5,
-            canUseToday: (response.data.remaining_usage || 5) > 0
+            dailyUsed: response.data.dailyUsed || response.data.daily_usage || 0,
+            dailyLimit: response.data.dailyLimit || response.data.daily_limit || 5,
+            remainingToday: response.data.remainingUsage || response.data.remaining_usage || 5,
+            canUseToday: (response.data.remainingUsage || response.data.remaining_usage || 5) > 0
           }
         }
       } catch (error) {
@@ -374,11 +375,12 @@ export default {
     },
     updateUsageInfo(usageInfo) {
       if (usageInfo) {
+        // APIからのレスポンスのフィールド名に合わせる（両方のパターンに対応）
         this.aiUsageInfo = {
-          dailyUsed: usageInfo.daily_usage || 0,
-          dailyLimit: usageInfo.daily_limit || 5,
-          remainingToday: usageInfo.remaining_usage || 0,
-          canUseToday: (usageInfo.remaining_usage || 0) > 0
+          dailyUsed: usageInfo.dailyUsed || usageInfo.daily_usage || 0,
+          dailyLimit: usageInfo.dailyLimit || usageInfo.daily_limit || 5,
+          remainingToday: usageInfo.remainingUsage || usageInfo.remaining_usage || 0,
+          canUseToday: (usageInfo.remainingUsage || usageInfo.remaining_usage || 0) > 0
         }
       }
     },


### PR DESCRIPTION
- キャメルケース（dailyUsed）とスネークケース（daily_usage）の両方に対応
- loadAIUsageInfoとupdateUsageInfoの両メソッドを修正
- これにより利用状況が正しく表示されるように

🤖 Generated with [Claude Code](https://claude.ai/code)