### PR TITLE
fix: 利用上限判定ロジックを修正

### DIFF
--- a/src/components/AIAnalysisView.vue
+++ b/src/components/AIAnalysisView.vue
@@ -317,11 +317,17 @@ export default {
         const response = await apiFacade.getAIUsage()
         if (response.success) {
           // APIからのレスポンスのフィールド名に合わせる（キャメルケース）
+          const dailyUsed = response.data.dailyUsed || response.data.daily_usage || 0
+          const dailyLimit = response.data.dailyLimit || response.data.daily_limit || 5
+          // remainingUsageがない場合は、limitからusedを引いて計算
+          const remaining = response.data.remainingUsage || response.data.remaining_usage || 
+                           (dailyLimit - dailyUsed)
+          
           this.aiUsageInfo = {
-            dailyUsed: response.data.dailyUsed || response.data.daily_usage || 0,
-            dailyLimit: response.data.dailyLimit || response.data.daily_limit || 5,
-            remainingToday: response.data.remainingUsage || response.data.remaining_usage || 5,
-            canUseToday: (response.data.remainingUsage || response.data.remaining_usage || 5) > 0
+            dailyUsed: dailyUsed,
+            dailyLimit: dailyLimit,
+            remainingToday: remaining,
+            canUseToday: remaining > 0
           }
         }
       } catch (error) {
@@ -376,11 +382,17 @@ export default {
     updateUsageInfo(usageInfo) {
       if (usageInfo) {
         // APIからのレスポンスのフィールド名に合わせる（両方のパターンに対応）
+        const dailyUsed = usageInfo.dailyUsed || usageInfo.daily_usage || 0
+        const dailyLimit = usageInfo.dailyLimit || usageInfo.daily_limit || 5
+        // remainingUsageがない場合は、limitからusedを引いて計算
+        const remaining = usageInfo.remainingUsage || usageInfo.remaining_usage || 
+                         (dailyLimit - dailyUsed)
+        
         this.aiUsageInfo = {
-          dailyUsed: usageInfo.dailyUsed || usageInfo.daily_usage || 0,
-          dailyLimit: usageInfo.dailyLimit || usageInfo.daily_limit || 5,
-          remainingToday: usageInfo.remainingUsage || usageInfo.remaining_usage || 0,
-          canUseToday: (usageInfo.remainingUsage || usageInfo.remaining_usage || 0) > 0
+          dailyUsed: dailyUsed,
+          dailyLimit: dailyLimit,
+          remainingToday: remaining,
+          canUseToday: remaining > 0
         }
       }
     },


### PR DESCRIPTION
- remainingUsageがAPIから返されない場合、dailyLimit - dailyUsedで計算
- これにより5回中5回使用時に正しく「本日の利用上限に達しました」が表示される
- デフォルト値の5を使わず、実際の残り回数を計算

🤖 Generated with [Claude Code](https://claude.ai/code)