### PR TITLE
fix: Googleアカウントでログインしたときの画像取得がうまく行かない問題の解決

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -92,7 +92,13 @@ export default {
           this.imageKey = Date.now();
           
           if (response.data && response.data.profile_image_url) {
-            await this.loadImageWithAuth(response.data.profile_image_url);
+            if (response.data.is_google_image) {
+              // Google画像は認証なしで直接表示
+              this.imageDataUrl = response.data.profile_image_url;
+            } else {
+              // ローカルアップロード画像は認証付きでfetch
+              await this.loadImageWithAuth(response.data.profile_image_url);
+            }
           } else {
             this.imageDataUrl = null;
           }

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -631,9 +631,15 @@ export default {
           console.log('Profile image info updated:', this.profileImageInfo);
           this.imageKey = Date.now(); // データ取得時もキャッシュバスティング
           
-          // 画像URLが存在する場合、認証付きでフェッチしてBase64に変換
+          // 画像URLが存在する場合、Google画像か判定して適切に処理
           if (response.data.profile_image_url) {
-            await this.loadImageWithAuth(response.data.profile_image_url);
+            if (response.data.is_google_image) {
+              // Google画像は認証なしで直接表示
+              this.imageDataUrl = response.data.profile_image_url;
+            } else {
+              // ローカルアップロード画像は認証付きでfetch
+              await this.loadImageWithAuth(response.data.profile_image_url);
+            }
           } else {
             this.imageDataUrl = null;
           }
@@ -712,9 +718,15 @@ export default {
           console.log('Profile image updated:', response.data);
           this.showSuccess(response.data.message || 'プロフィール画像をアップロードしました');
           
-          // アップロード成功時は画像を即座に認証付きで読み込み
+          // アップロード成功時は画像を即座に適切に読み込み
           if (response.data.profile_image_url) {
-            await this.loadImageWithAuth(response.data.profile_image_url);
+            if (response.data.is_google_image) {
+              // Google画像は認証なしで直接表示
+              this.imageDataUrl = response.data.profile_image_url;
+            } else {
+              // ローカルアップロード画像は認証付きでfetch
+              await this.loadImageWithAuth(response.data.profile_image_url);
+            }
           }
           
           // ヘッダーにプロフィール画像更新を通知


### PR DESCRIPTION
Google の外部画像 URL を認証付きフェッチで修正

Google 画像とローカルアップロード画像を区別

Google 画像: 認証なしで直接 URL を利用

ローカル画像: 認証付きフェッチ + Base64 変換を使用

Settings コンポーネントと Header コンポーネントの両方に修正を適用